### PR TITLE
New loadout check & ticket loss mechanics

### DIFF
--- a/src/dct/assets/Player.lua
+++ b/src/dct/assets/Player.lua
@@ -37,9 +37,11 @@ local class   = require("libs.namedclass")
 local dctenum = require("dct.enum")
 local dctutils= require("dct.utils")
 local AssetBase = require("dct.assets.AssetBase")
+local cmds    = require("dct.ui.cmds")
 local uimenu  = require("dct.ui.groupmenu")
 local loadout = require("dct.systems.loadouts")
 local State   = require("dct.libs.State")
+local Timer   = require("dct.libs.Timer")
 local settings = _G.dct.settings
 
 local notifymsg =
@@ -137,6 +139,7 @@ end
 function OccupiedState:__init(inair)
 	self.inair = inair
 	self.loseticket = false
+	self.loadouttimer = nil
 	self.bleedctr = 0
 	self.bleedperiod = 5
 	self.bleedwarn = false
@@ -157,6 +160,7 @@ function OccupiedState:enter(asset)
 end
 
 function OccupiedState:exit(asset)
+	asset.loadouttimer = nil
 	if self.loseticket then
 		asset:setDead(true)
 	end
@@ -199,10 +203,71 @@ function OccupiedState:_bleed(asset)
 	return state
 end
 
+function OccupiedState:_kickForNuke(asset)
+	trigger.action.outTextForGroup(asset.groupId,
+		"You have been kicked for carrying a nuclear weapon.", 20, true)
+	return EmptyState(dctenum.kickCode.NUKE)
+end
+
+function OccupiedState:_checkPayload(asset, display)
+	local ok, costs, nuke = loadout.check(asset)
+	if nuke then
+		return self:_kickForNuke(asset), ok
+	end
+	if display and not ok then
+		-- Show the current loadout to the player
+		local CheckPayloadCmd = cmds[dctenum.uiRequestType.CHECKPAYLOAD]
+		local msg = "You are over budget! Re-arm and re-check before departing, "..
+			"or you will be punished!\n"..CheckPayloadCmd.buildSummary(costs)
+		trigger.action.outTextForGroup(asset.groupId, msg, 60, false)
+	end
+	return nil, ok
+end
+
+function OccupiedState:_tickLoadoutTimer(asset)
+	-- FIXME: this function does not obey DCT runtime quotas,
+	-- so very slow loadout checks can slow down the server
+	if self.loadouttimer ~= nil then
+		self.loadouttimer:update()
+		local remain, _ = self.loadouttimer:remain()
+		if remain > 0 then
+			trigger.action.outTextForGroup(asset.groupId,
+				string.format("TIME LEFT: %d seconds\n\n", math.floor(remain))..
+				"You have taken off with an invalid loadout! Jettison all stores "..
+				"immediately and then land to re-arm!", 10, true)
+			local _, ok = self:_checkPayload(asset, false)
+			if ok then
+				self.loadouttimer = nil
+				trigger.action.outTextForGroup(asset.groupId, "You are now "..
+					"within payload limits and can safely land to re-arm.", 20, true)
+			else
+				timer.scheduleFunction(function() self:_tickLoadoutTimer(asset) end,
+					nil, timer.getTime() + 1)
+			end
+		else
+			-- ¯\_(ツ)_/¯
+			local grp = Group.getByName(asset.name)
+			local unit = grp:getUnit(1):getName()
+			trigger.action.setUnitInternalCargo(unit, 1000000)
+			trigger.action.outTextForGroup(asset.groupId, "TIME LEFT: 0 seconds\n\n"..
+				"You have taken off with an invalid loadout and failed to comply "..
+				"with orders in time. Your aircraft has been deprived of its lift.",
+				20, true)
+		end
+	end
+end
+
 function OccupiedState:update(asset)
 	local grp = Group.getByName(asset.name)
 	if grp == nil then
 		return EmptyState(dctenum.kickCode.EMPTY)
+	end
+	-- Periodic ground loadout check
+	if not self.inair then
+		local newstate, _ = self:_checkPayload(asset, true)
+		if newstate ~= nil then
+			return newstate
+		end
 	end
 	return self:_bleed(asset)
 end
@@ -222,13 +287,13 @@ end
 function OccupiedState:handleTakeoff(asset, _ --[[event]])
 	self.loseticket = true
 	self.inair = true
-	local ok = loadout.check(asset)
+	local ok, _, nuke = loadout.check(asset)
+	if nuke then
+		return self:_kickForNuke(asset)
+	end
 	if not ok then
-		trigger.action.outTextForGroup(asset.groupId,
-			"You have been removed to spectator for flying with an "..
-			"invalid loadout. "..notifymsg,
-			20, true)
-		return EmptyState(dctenum.kickCode.LOADOUT)
+		self.loadouttimer = Timer(60)
+		self:_tickLoadoutTimer(asset)
 	end
 	return nil
 end
@@ -246,6 +311,7 @@ function OccupiedState:handleLand(asset, event)
 
 	if (airbase and airbase.owner == asset.owner) or
 	   event.place:getName() == asset.airbase then
+		self.loadouttimer = nil
 		self.loseticket = false
 		self.inair = false
 		trigger.action.outTextForGroup(asset.groupId,

--- a/src/dct/assets/Player.lua
+++ b/src/dct/assets/Player.lua
@@ -231,16 +231,16 @@ function OccupiedState:_tickLoadoutTimer(asset)
 		self.loadouttimer:update()
 		local remain, _ = self.loadouttimer:remain()
 		if remain > 0 then
-			trigger.action.outTextForGroup(asset.groupId,
-				string.format("TIME LEFT: %d seconds\n\n", math.floor(remain))..
-				"You have taken off with an invalid loadout! Jettison all stores "..
-				"immediately and then land to re-arm!", 10, true)
 			local _, ok = self:_checkPayload(asset, false)
 			if ok then
 				self.loadouttimer = nil
 				trigger.action.outTextForGroup(asset.groupId, "You are now "..
-					"within payload limits and can safely land to re-arm.", 20, true)
+					"within payload limits and can safely land to re-arm.", 30, true)
 			else
+				trigger.action.outTextForGroup(asset.groupId,
+					"You have taken off with an illegal loadout! Jettison all stores "..
+					"immediately and then land to re-arm!\n\n"..
+					string.format("TIME LEFT: %d seconds", math.floor(remain)), 10, true)
 				timer.scheduleFunction(function() self:_tickLoadoutTimer(asset) end,
 					nil, timer.getTime() + 1)
 			end
@@ -249,10 +249,10 @@ function OccupiedState:_tickLoadoutTimer(asset)
 			local grp = Group.getByName(asset.name)
 			local unit = grp:getUnit(1):getName()
 			trigger.action.setUnitInternalCargo(unit, 1000000)
-			trigger.action.outTextForGroup(asset.groupId, "TIME LEFT: 0 seconds\n\n"..
+			trigger.action.outTextForGroup(asset.groupId,
 				"You have taken off with an invalid loadout and failed to comply "..
-				"with orders in time. Your aircraft has been deprived of its lift.",
-				20, true)
+				"with orders in time. Your aircraft has been made unflyable.\n\n"..
+				"TIME LEFT: 0 seconds\n\n", 30, true)
 		end
 	end
 end

--- a/src/dct/assets/Player.lua
+++ b/src/dct/assets/Player.lua
@@ -246,6 +246,7 @@ function OccupiedState:_tickLoadoutTimer(asset)
 			end
 		else
 			-- ¯\_(ツ)_/¯
+			self.loseticket = false
 			local grp = Group.getByName(asset.name)
 			local unit = grp:getUnit(1):getName()
 			trigger.action.setUnitInternalCargo(unit, 1000000)

--- a/src/dct/assets/Player.lua
+++ b/src/dct/assets/Player.lua
@@ -146,10 +146,10 @@ function OccupiedState:__init(inair)
 	self._eventhandlers = {
 		[world.event.S_EVENT_BIRTH]             = self.handleSwitchOccupied,
 		[world.event.S_EVENT_TAKEOFF]           = self.handleTakeoff,
-		[world.event.S_EVENT_EJECTION]          = self.handleLoseTicket,
-		[world.event.S_EVENT_DEAD]              = self.handleLoseTicket,
-		[world.event.S_EVENT_PILOT_DEAD]        = self.handleLoseTicket,
-		[world.event.S_EVENT_CRASH]             = self.handleLoseTicket,
+		[world.event.S_EVENT_EJECTION]          = self.handleDead,
+		[world.event.S_EVENT_DEAD]              = self.handleDead,
+		[world.event.S_EVENT_PILOT_DEAD]        = self.handleDead,
+		[world.event.S_EVENT_CRASH]             = self.handleDead,
 		[world.event.S_EVENT_LAND]              = self.handleLand,
 	}
 end
@@ -322,8 +322,7 @@ function OccupiedState:handleLand(asset, event)
 	return nil
 end
 
-function OccupiedState:handleLoseTicket(--[[asset, event]])
-	self.loseticket = true
+function OccupiedState:handleDead(--[[asset, event]])
 	return EmptyState(dctenum.kickCode.DEAD)
 end
 

--- a/src/dct/libs/kickinfo.lua
+++ b/src/dct/libs/kickinfo.lua
@@ -14,6 +14,7 @@ enum.kickCode = {
 	["DEAD"]    = 4,
 	["LOADOUT"] = 5,
 	["MISSION"] = 6,
+	["NUKE"]    = 7,
 }
 
 enum.kickReason = {
@@ -28,10 +29,12 @@ enum.kickReason = {
 	[enum.kickCode.DEAD] =
 		"you died, re-slot to continue.",
 	[enum.kickCode.LOADOUT] =
-		"payload violation, you attempted to takeoff with restricted "..
+		"payload violation, you took off with restricted "..
 		"weapons. Check the loadout limits.",
 	[enum.kickCode.MISSION] =
 		"no mission assigned. Must have a mission assigned.",
+	[enum.kickCode.NUKE] =
+		"you are not allowed to use nukes in this server.",
 }
 
 return enum

--- a/src/dct/settings/theater.lua
+++ b/src/dct/settings/theater.lua
@@ -149,10 +149,12 @@ local function theatercfgs(config)
 				["RN-24"] = {
 					["cost"]     = enum.WPNINFCOST,
 					["category"] = enum.weaponCategory.AG,
+					["nuclear"]  = true,
 				},
 				["RN-28"] = {
 					["cost"]     = enum.WPNINFCOST,
 					["category"] = enum.weaponCategory.AG,
+					["nuclear"]  = true,
 				},
 			},
 		}, {

--- a/src/dct/systems/loadouts.lua
+++ b/src/dct/systems/loadouts.lua
@@ -16,6 +16,7 @@ local function totalPayload(grp, limits)
 	local unit = grp:getUnit(1)
 	local restrictedWeapons = settings.restrictedweapons
 	local payload = unit:getAmmo()
+	local nuke = false
 	local total = {}
 	for _, v in pairs(enum.weaponCategory) do
 		total[v] = {
@@ -37,6 +38,11 @@ local function totalPayload(grp, limits)
 		total[category].current =
 			total[category].current + (wpncnt * cost)
 
+		if restriction.nuclear then
+			env.info("NUCLEAR WEAPON DETECTED")
+			nuke = true
+		end
+
 		-- TODO: it seems cannons have an internal category of 0,
 		-- what are the other categories?
 		if wpn.desc.category > 0 then
@@ -47,23 +53,24 @@ local function totalPayload(grp, limits)
 			})
 		end
 	end
-	return total
+	return total, nuke
 end
 
--- returns a two tuple;
+-- returns a triple:
 --   first arg (boolean) is payload valid
 --   second arg (table) total cost per category of the payload, also
 --       includes the max allowed for the airframe
+--   third arg (boolean) payload contains a nuclear weapon
 local function validatePayload(grp, limits)
-	local total = totalPayload(grp, limits)
+	local total, nuke = totalPayload(grp, limits)
 
 	for _, cost in pairs(total) do
 		if cost.current > cost.max then
-			return false, total
+			return false, total, nuke
 		end
 	end
 
-	return true, total
+	return true, total, nuke
 end
 
 local loadout = {}

--- a/src/dct/systems/loadouts.lua
+++ b/src/dct/systems/loadouts.lua
@@ -76,8 +76,14 @@ end
 local loadout = {}
 
 function loadout.check(player)
-	return validatePayload(Group.getByName(player.name),
-		player.payloadlimits)
+	local group = Group.getByName(player.name)
+	if group ~= nil then
+		return validatePayload(Group.getByName(player.name),
+			player.payloadlimits)
+	else
+		-- TODO: log something here
+		return true, {}, false
+	end
 end
 
 function loadout.addmenu(asset, menu, handler, context)

--- a/src/dct/systems/loadouts.lua
+++ b/src/dct/systems/loadouts.lua
@@ -39,7 +39,6 @@ local function totalPayload(grp, limits)
 			total[category].current + (wpncnt * cost)
 
 		if restriction.nuclear then
-			env.info("NUCLEAR WEAPON DETECTED")
 			nuke = true
 		end
 

--- a/src/dct/systems/weaponstracking.lua
+++ b/src/dct/systems/weaponstracking.lua
@@ -138,7 +138,7 @@ function WeaponsTracker:event(event)
 		Logger:debug(string.format("%s - weapon not valid "..
 			"typename: %s; initiator: ", self.__clsname,
 			event.weapon:getTypeName(),
-			event.initiator.getName()))
+			event.initiator:getName()))
 		return
 	end
 	self.trackedwpns[event.weapon.id_] = DCTWeapon(event.weapon,

--- a/src/dct/ui/cmds.lua
+++ b/src/dct/ui/cmds.lua
@@ -128,18 +128,9 @@ function CheckPayloadCmd:__init(theater, data)
 	self.name = "CheckPayloadCmd:"..data.name
 end
 
-function CheckPayloadCmd:_execute(_ --[[time]], _ --[[cmdr]])
-	local msg
-	local ok, costs = loadout.check(self.asset)
-	if ok then
-		msg = "Valid loadout, you may depart. Good luck!"
-	else
-		msg = "You are over budget! Re-arm before departing, or "..
-			"you will be kicked to spectator!"
-	end
-
+function CheckPayloadCmd.buildSummary(costs)
 	-- print cost summary
-	msg = msg.."\n== Loadout Summary:"
+	local msg = "== Loadout Summary:"
 	for cat, val in pairs(enum.weaponCategory) do
 		if val ~= enum.weaponCategory.UNRESTRICTED then
 			msg = msg..string.format("\n  %s cost: %d / %d",
@@ -168,6 +159,18 @@ function CheckPayloadCmd:_execute(_ --[[time]], _ --[[cmdr]])
 	end
 
 	return msg
+end
+
+function CheckPayloadCmd:_execute(_ --[[time]], _ --[[cmdr]])
+	local ok, totals = loadout.check(self.asset)
+	if ok then
+		return "Valid loadout, you may depart. Good luck!\n"
+			..self.buildSummary(totals)
+	else
+		return "You are over budget! Re-arm before departing, or "..
+			"you will be punished!\n"
+			..self.buildSummary(totals)
+	end
 end
 
 

--- a/tests/test-ui-cmds.lua
+++ b/tests/test-ui-cmds.lua
@@ -193,7 +193,7 @@ local testcmds = {
 		},
 		["assert"]     = true,
 		["expected"]   = "You are over budget! Re-arm before departing, or "..
-			"you will be kicked to spectator!\n"..
+			"you will be punished!\n"..
 			"== Loadout Summary:\n"..
 			"  AA cost: 0 / 5\n"..
 			"  AG cost: 5000 / 20\n"..


### PR DESCRIPTION
* Loadout is periodically checked in the background every two minutes for players on the ground, and if over the limit, it shows them the total (with the weapons and costs listed)
* When players take off, it shows a warning telling them to jettison weapons or land, with a one minute countdown to punishment (addition of 1 million kg as in pgaw)
* If a player is detected with a nuke, either in the periodic two min check or when taking off, they're immediately removed from the slot with no prior warning (just a message telling them why they were removed)
* Tickets now aren't lost on the ground, or when punished for taking an illegal loadout