### PR TITLE
player: fix untracked airbases not resetting inAir flag

### DIFF
--- a/src/dct/ui/cmds.lua
+++ b/src/dct/ui/cmds.lua
@@ -219,7 +219,7 @@ function CheckPayloadCmd:_execute(_ --[[time]], _ --[[cmdr]])
 		local ok, costs = loadout.check(self.asset)
 		return self:buildMessage(ok, costs)
 	end
-	return "Payload check is only allowed when landed at a friendly airbase"
+	return "Payload check is only allowed when landed on the ground."
 end
 
 local MissionCmd = class("MissionCmd", UICmd)

--- a/src/dct/ui/cmds.lua
+++ b/src/dct/ui/cmds.lua
@@ -219,7 +219,7 @@ function CheckPayloadCmd:_execute(_ --[[time]], _ --[[cmdr]])
 		local ok, costs = loadout.check(self.asset)
 		return self:buildMessage(ok, costs)
 	end
-	return "Payload check is only allowed when landed on the ground."
+	return "Payload check is only allowed when landed."
 end
 
 local MissionCmd = class("MissionCmd", UICmd)


### PR DESCRIPTION
Attempt to fix an issue with payload checks still thinking the user is in the air when landing at a non-theater airbase (ie. Ramat David in Flashpoint Levant), causing them to not receive warnings when loading weapons over the limit.

NOT TESTED IN-GAME YET.